### PR TITLE
feat : 발급 된 토큰 값 만료 시 새로운 토큰 값으로 갱신 기능 추가

### DIFF
--- a/server/src/main/java/com/watchtogether/server/components/jwt/TokenProvider.java
+++ b/server/src/main/java/com/watchtogether/server/components/jwt/TokenProvider.java
@@ -1,7 +1,11 @@
 package com.watchtogether.server.components.jwt;
 
-import static com.watchtogether.server.exception.type.AuthErrorCode.EXPIRED_TOKEN;
-import static com.watchtogether.server.exception.type.AuthErrorCode.INVALID_TOKEN;
+import static com.watchtogether.server.exception.type.TokenErrorCode.EXPIRED_ACCESS_TOKEN;
+import static com.watchtogether.server.exception.type.TokenErrorCode.EXPIRED_REFRESH_TOKEN;
+import static com.watchtogether.server.exception.type.TokenErrorCode.EXPIRED_TOKEN;
+import static com.watchtogether.server.exception.type.TokenErrorCode.INVALID_ACCESS_TOKEN;
+import static com.watchtogether.server.exception.type.TokenErrorCode.INVALID_REFRESH_TOKEN;
+import static com.watchtogether.server.exception.type.TokenErrorCode.INVALID_TOKEN;
 
 import com.watchtogether.server.users.service.impl.UserServiceImpl;
 import io.jsonwebtoken.Claims;
@@ -25,8 +29,10 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class TokenProvider {
 
-    private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60;   // 1 hour
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;   // 1 day
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60;   // 1 hour
     private static final String KEY_ROLES = "roles";
+    public static final String SUCCESS = "true";
     private final UserServiceImpl userServiceImpl;
 
     @Value("{spring.jwt.secret}")
@@ -39,7 +45,7 @@ public class TokenProvider {
      * @param roles  사용자 역할
      * @return Jwt 값
      */
-    public String generateToken(String userId, String roles) {
+    public String generateAccessToken(String userId, String roles) {
 
         // 사용의 권한정보 저장
         Claims claims = Jwts.claims().setSubject(userId);
@@ -49,7 +55,28 @@ public class TokenProvider {
         Date now = new Date();
 
         // 토큰 만료 시간
-        Date expiredDate = new Date(now.getTime() + TOKEN_EXPIRE_TIME);
+        Date expiredDate = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME);
+
+        // 토큰에 주입
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now) // 토큰 생성된 시간
+            .setExpiration(expiredDate) // 토큰 만료 시간
+            .signWith(SignatureAlgorithm.HS512, secretKey) // 사용할 암호화 알고리즘, 비밀키
+            .compact();
+    }
+
+    public String generateRefreshToken(String roles) {
+
+        // 사용의 권한정보 저장
+        Claims claims = Jwts.claims().setSubject(null);
+        claims.put(KEY_ROLES, roles);
+
+        // 토큰 생성된 시간
+        Date now = new Date();
+
+        // 토큰 만료 시간
+        Date expiredDate = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME);
 
         // 토큰에 주입
         return Jwts.builder()
@@ -61,7 +88,19 @@ public class TokenProvider {
     }
 
     public Authentication getAuthentication(String jwt, HttpServletRequest request) {
-        UserDetails userDetails = this.userServiceImpl.loadUserByUsername(getUserId(jwt, request));
+        UserDetails userDetails = userServiceImpl.loadUserByUsername(getUserId(jwt, request));
+
+        return new UsernamePasswordAuthenticationToken(userDetails, "",
+            userDetails.getAuthorities());
+    }
+
+    // jwt로 인증 정보를 조회
+    public Authentication getAuthentication(String token) {
+
+        // jwt 에서 Claims 추출
+        Claims claims = parseClaims(token);
+
+        UserDetails userDetails = userServiceImpl.loadUserByUsername(claims.getSubject());
 
         return new UsernamePasswordAuthenticationToken(userDetails, "",
             userDetails.getAuthorities());
@@ -91,6 +130,35 @@ public class TokenProvider {
         return !claims.getExpiration().before(new Date());
     }
 
+    // refresh 토큰 유효성 및 만료일자 확인
+    public String validToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+            return SUCCESS;
+        } catch (ExpiredJwtException e) {
+            log.error(e.toString());
+            return EXPIRED_REFRESH_TOKEN.getErrorCode();
+
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error(e.toString());
+            return INVALID_REFRESH_TOKEN.getErrorCode();
+        }
+    }
+
+    public String validAccessToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+            return SUCCESS;
+        } catch (ExpiredJwtException e) {
+            log.error(e.toString());
+            return EXPIRED_ACCESS_TOKEN.getErrorCode();
+
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error(e.toString());
+            return INVALID_ACCESS_TOKEN.getErrorCode();
+        }
+    }
+
 
     private Claims parseClaims(String token, HttpServletRequest request) {
 
@@ -109,5 +177,14 @@ public class TokenProvider {
             request.setAttribute("exception", INVALID_TOKEN.getErrorCode());
         }
         return claims;
+    }
+
+    // jwt 토큰 복화해서 가져오기
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
     }
 }

--- a/server/src/main/java/com/watchtogether/server/config/SecurityConfig.java
+++ b/server/src/main/java/com/watchtogether/server/config/SecurityConfig.java
@@ -89,6 +89,7 @@ public class SecurityConfig {
             .authorizeRequests()    //요청에 대한 권한 체크
             .requestMatchers(CorsUtils::isPreFlightRequest).permitAll() //  Preflight 요청은 허용
             .antMatchers(
+                "/api/v1/refresh-token",
                 "/api/v1/users/sign-in",
                 "/api/v1/users/sign-up/**",
                 "/api/v1/users/reset-password/**").permitAll()

--- a/server/src/main/java/com/watchtogether/server/exception/TokenException.java
+++ b/server/src/main/java/com/watchtogether/server/exception/TokenException.java
@@ -1,0 +1,18 @@
+package com.watchtogether.server.exception;
+
+
+import com.watchtogether.server.exception.type.TokenErrorCode;
+import lombok.Getter;
+
+@Getter
+public class TokenException extends RuntimeException {
+
+    private final TokenErrorCode refreshTokenErrorCode;
+    private final int errorStatus;
+
+    public TokenException(TokenErrorCode refreshTokenErrorCode) {
+        super(refreshTokenErrorCode.getDetail());
+        this.errorStatus = refreshTokenErrorCode.getErrorStatus();
+        this.refreshTokenErrorCode = refreshTokenErrorCode;
+    }
+}

--- a/server/src/main/java/com/watchtogether/server/exception/handler/CustomExceptionHandler.java
+++ b/server/src/main/java/com/watchtogether/server/exception/handler/CustomExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.watchtogether.server.exception.handler;
 
 import com.watchtogether.server.exception.PartyException;
+import com.watchtogether.server.exception.TokenException;
+import com.watchtogether.server.exception.response.TokenExceptionResponse;
 import com.watchtogether.server.exception.response.UserExceptionResponse;
 import com.watchtogether.server.exception.UserException;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,14 @@ public class CustomExceptionHandler {
 
         return ResponseEntity.badRequest()
                 .body(new UserExceptionResponse(e.getErrorStatus(),e.getUserErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler({TokenException.class})
+    public ResponseEntity<TokenExceptionResponse> RefreshTokenException(final TokenException e) {
+        log.error("UserException is occurred. ", e);
+
+        return ResponseEntity.badRequest()
+            .body(new TokenExceptionResponse(e.getErrorStatus(),e.getRefreshTokenErrorCode(), e.getMessage()));
     }
 
 }

--- a/server/src/main/java/com/watchtogether/server/exception/response/TokenExceptionResponse.java
+++ b/server/src/main/java/com/watchtogether/server/exception/response/TokenExceptionResponse.java
@@ -1,0 +1,22 @@
+package com.watchtogether.server.exception.response;
+
+import com.watchtogether.server.exception.type.TokenErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+// 에러 발생 시 던져줄 model class
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TokenExceptionResponse {
+
+    private int status;
+    private TokenErrorCode errorCode;
+    private String Message;
+
+}

--- a/server/src/main/java/com/watchtogether/server/exception/type/TokenErrorCode.java
+++ b/server/src/main/java/com/watchtogether/server/exception/type/TokenErrorCode.java
@@ -1,0 +1,27 @@
+package com.watchtogether.server.exception.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TokenErrorCode {
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), "UNAUTHORIZED", "인증 정보가 없습니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "EXPIRED_TOKEN", "사용 가능 시간이 만료된 토큰 값입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), "EXPIRED_REFRESH_TOKEN", "사용 가능 시간이 만료된 refresh 토큰 값입니다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED.value(), "EXPIRED_ACCESS_TOKEN", "사용 가능 시간이 만료된 access 토큰 값입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), "INVALID_REFRESH_TOKEN", "refresh 토큰 서명 값이 일치하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "INVALID_TOKEN", "토큰 서명 값이 일치하지 않습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED.value(), "INVALID_ACCESS_TOKEN", "access 토큰 서명 값이 일치하지 않습니다."),
+    INVALID_TOKEN_PREFIX(HttpStatus.UNAUTHORIZED.value(), "INVALID_TOKEN_PREFIX", "Bearer 값을 확인해주세요."),
+    IS_EMPTY_TOKEN(HttpStatus.UNAUTHORIZED.value(), "IS_EMPTY_TOKEN", "토큰 값이 비어있습니다."),
+    IS_EMPTY_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED.value(), "IS_EMPTY_ACCESS_TOKEN", "access 토큰 값이 비어있습니다."),
+    IS_EMPTY_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), "IS_EMPTY_REFRESH_TOKEN", "refresh 토큰 값이 비어있습니다."),
+    WRONG_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), "WRONG_REFRESH_TOKEN", "fresh 토큰 값이 일치하지 않습니다.");
+
+    private final int errorStatus;
+    private final String errorCode;
+    private final String detail;
+}

--- a/server/src/main/java/com/watchtogether/server/users/controller/TokenController.java
+++ b/server/src/main/java/com/watchtogether/server/users/controller/TokenController.java
@@ -1,0 +1,39 @@
+package com.watchtogether.server.users.controller;
+
+import static com.watchtogether.server.users.domain.type.UserSuccess.SUCCESS_REFRESH_TOKEN;
+
+import com.watchtogether.server.users.domain.dto.TokenDto;
+import com.watchtogether.server.users.domain.model.Token;
+import com.watchtogether.server.users.service.JwtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "토큰(TokenController)", description = "토큰 API")
+@RequestMapping("/api/v1")
+public class TokenController {
+
+    private final JwtService jwtService;
+
+    @PostMapping("/refresh-token")
+    @Operation(summary = "토큰 값 갱신", description = "만료된 토큰 값 갱신을 위한 요청.")
+    public ResponseEntity<Token.Response> refreshToken(
+        @Validated @RequestBody Token.Request token) {
+
+        TokenDto tokenDto = jwtService.updateToken(token.getAccessToken(), token.getRefreshToken());
+
+        return ResponseEntity.ok(
+            new Token.Response(
+                tokenDto.getAccessToken(),
+                tokenDto.getRefreshToken(),
+                SUCCESS_REFRESH_TOKEN.getMessage()));
+    }
+}

--- a/server/src/main/java/com/watchtogether/server/users/controller/UserController.java
+++ b/server/src/main/java/com/watchtogether/server/users/controller/UserController.java
@@ -87,12 +87,18 @@ public class UserController {
         UserDto userDto = userService.signInUser(request.getEmail(), request.getPassword());
 
         // token 발행
-        String token = tokenProvider.generateToken(userDto.getEmail(), userDto.getRoles());
+        String accessToken = tokenProvider.generateAccessToken(userDto.getEmail(),
+            userDto.getRoles());
+        String refreshToken = tokenProvider.generateRefreshToken(userDto.getRoles());
+
+        // refresh_token 값 , 유효기간 저장
+        userService.saveRefreshToken(userDto.getEmail(), refreshToken);
 
         return ResponseEntity.ok(
             new SignInUser.Response(
                 userDto.getEmail(),
-                token,
+                accessToken,
+                refreshToken,
                 SUCCESS_SIGNIN.getMessage()));
     }
 
@@ -101,7 +107,7 @@ public class UserController {
     public ResponseEntity<MyPageUser.Response> myPage(
         @AuthenticationPrincipal User user) {
 
-        UserDto userDto = userService.myPageUser(user.getEmail());
+        UserDto userDto = userService.InfoUser(user.getEmail());
 
         return ResponseEntity.ok(
             new MyPageUser.Response(

--- a/server/src/main/java/com/watchtogether/server/users/domain/dto/RefreshTokenDto.java
+++ b/server/src/main/java/com/watchtogether/server/users/domain/dto/RefreshTokenDto.java
@@ -1,0 +1,17 @@
+package com.watchtogether.server.users.domain.dto;
+
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RefreshTokenDto {
+    public String refreshToken;
+    public Date refreshTokenLimitDt;
+
+}

--- a/server/src/main/java/com/watchtogether/server/users/domain/dto/TokenDto.java
+++ b/server/src/main/java/com/watchtogether/server/users/domain/dto/TokenDto.java
@@ -1,0 +1,17 @@
+package com.watchtogether.server.users.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenDto {
+
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/server/src/main/java/com/watchtogether/server/users/domain/entitiy/User.java
+++ b/server/src/main/java/com/watchtogether/server/users/domain/entitiy/User.java
@@ -72,7 +72,8 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "reset_password_limit_dt")
     private LocalDateTime resetPasswordLimitDt;
 
-
+    @Column(name = "refresh_token")
+    private String refreshToken;
 
 
     @Override

--- a/server/src/main/java/com/watchtogether/server/users/domain/model/SignInUser.java
+++ b/server/src/main/java/com/watchtogether/server/users/domain/model/SignInUser.java
@@ -36,8 +36,11 @@ public class SignInUser {
         @Schema(description = "아이디", example = "abc@ikdmd.kg.lr")
         private String email;
 
-        @Schema(description = "토큰 값")
-        private String token;
+        @Schema(description = "access 토큰 값")
+        private String accessToken;
+
+        @Schema(description = "refresh 토큰 값")
+        private String refreshToken;
 
         @Schema(description = "메시지")
         private String message;

--- a/server/src/main/java/com/watchtogether/server/users/domain/model/Token.java
+++ b/server/src/main/java/com/watchtogether/server/users/domain/model/Token.java
@@ -1,0 +1,46 @@
+package com.watchtogether.server.users.domain.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class Token {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "TokenRequest", description = "토큰 값 갱신을 위한 요청")
+    public static class Request {
+
+        @NotBlank(message = "access 토큰을 입력해주세요.")
+        @Schema(description = "access_token")
+        private String accessToken;
+
+
+        @NotBlank(message = "refresh 토큰을 입력해주세요.")
+        @Schema(description = "refresh_token")
+        private String refreshToken;
+
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "TokenResponse", description = "토큰 값 갱신 요청에 대한 응답")
+    public static class Response {
+
+        @Schema(description = "access_token")
+        private String accessToken;
+
+        @Schema(description = "refresh_token")
+        private String refreshToken;
+
+        @Schema(description = "성공 응답 메시지")
+        private String message;
+
+    }
+}

--- a/server/src/main/java/com/watchtogether/server/users/domain/type/UserSuccess.java
+++ b/server/src/main/java/com/watchtogether/server/users/domain/type/UserSuccess.java
@@ -17,7 +17,8 @@ public enum UserSuccess {
     SUCCESS_CHANGE_PASSWORD("패스워드 변경에 성공하였습니다."),
     SUCCESS_SEND_RESET_PASSWORD("패스워드 초기화 메일 전송에 성공하였습니다. 메일을 확인하여 코드를 입력해주세요."),
     SUCCESS_VERIFY_RESET_PASSWORD("패스워드 초기화 코드 인증에 성공하였습니다."),
-    SUCCESS_RESET_PASSWORD("패스워드 변경에 성공하였습니다.");
+    SUCCESS_RESET_PASSWORD("패스워드 변경에 성공하였습니다."),
+    SUCCESS_REFRESH_TOKEN("토큰 재발급에 성공하였습니다.");
 
     private String message;
 }

--- a/server/src/main/java/com/watchtogether/server/users/service/JwtService.java
+++ b/server/src/main/java/com/watchtogether/server/users/service/JwtService.java
@@ -1,0 +1,8 @@
+package com.watchtogether.server.users.service;
+
+import com.watchtogether.server.users.domain.dto.TokenDto;
+
+public interface JwtService {
+
+    TokenDto updateToken(String accessToken, String refreshToken);
+}

--- a/server/src/main/java/com/watchtogether/server/users/service/UserService.java
+++ b/server/src/main/java/com/watchtogether/server/users/service/UserService.java
@@ -40,7 +40,7 @@ public interface UserService extends UserDetailsService {
      * @param email
      * @return
      */
-    UserDto myPageUser(String email);
+    UserDto InfoUser(String email);
 
     /**
      * 사용자 닉네임 검색
@@ -68,21 +68,35 @@ public interface UserService extends UserDetailsService {
 
     /**
      * 사용자 비밀번호를 재설정 메일 전송
-     * @param email 이메일(아이디)
+     *
+     * @param email    이메일(아이디)
      * @param nickname 닉네임
      */
     void resetPassword(String email, String nickname);
 
     /**
      * 사용자 비밀번호 재설정 인증
+     *
      * @param code 패스워드 초기화 인증 코드
      */
     void authResetPassword(String code);
 
     /**
      * 사용자 비밀번호 재설정
-     * @param code 패스워드 초기화 인증 코드
+     *
+     * @param code     패스워드 초기화 인증 코드
      * @param password 새로운 패스워드
      */
     void updateNewPassword(String code, String password);
+
+
+    /**
+     * refresh 토큰 값 저장
+     *
+     * @param email        아이디
+     * @param refreshToken refresh 토큰 값
+     */
+    void saveRefreshToken(String email, String refreshToken);
+
+
 }

--- a/server/src/main/java/com/watchtogether/server/users/service/impl/JwtServiceImpl.java
+++ b/server/src/main/java/com/watchtogether/server/users/service/impl/JwtServiceImpl.java
@@ -1,0 +1,88 @@
+package com.watchtogether.server.users.service.impl;
+
+
+import static com.watchtogether.server.exception.type.TokenErrorCode.EXPIRED_REFRESH_TOKEN;
+import static com.watchtogether.server.exception.type.TokenErrorCode.INVALID_ACCESS_TOKEN;
+import static com.watchtogether.server.exception.type.TokenErrorCode.INVALID_REFRESH_TOKEN;
+import static com.watchtogether.server.exception.type.TokenErrorCode.IS_EMPTY_ACCESS_TOKEN;
+import static com.watchtogether.server.exception.type.TokenErrorCode.IS_EMPTY_REFRESH_TOKEN;
+import static com.watchtogether.server.exception.type.TokenErrorCode.WRONG_REFRESH_TOKEN;
+import static com.watchtogether.server.exception.type.UserErrorCode.NOT_FOUND_USER;
+
+import com.watchtogether.server.components.jwt.TokenProvider;
+import com.watchtogether.server.exception.TokenException;
+import com.watchtogether.server.exception.UserException;
+import com.watchtogether.server.users.domain.dto.TokenDto;
+import com.watchtogether.server.users.domain.entitiy.User;
+import com.watchtogether.server.users.domain.repository.UserRepository;
+import com.watchtogether.server.users.service.JwtService;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtServiceImpl implements JwtService {
+
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public TokenDto updateToken(String accessToken, String refreshToken) {
+
+        // access 토큰 값이 빈 경우
+        if (accessToken == null || accessToken.trim().length() == 0) {
+            throw new TokenException(IS_EMPTY_ACCESS_TOKEN);
+        }
+
+        // refresh 토큰 값이 빈 경우
+        if (refreshToken == null || refreshToken.trim().length() == 0) {
+            throw new TokenException(IS_EMPTY_REFRESH_TOKEN);
+        }
+
+        // 만료된 refresh 토큰 에러, 잘못된 refresh 토큰 값 에러
+        if (tokenProvider.validToken(refreshToken)
+            .equals(EXPIRED_REFRESH_TOKEN.getErrorCode())) {
+
+            throw new TokenException(EXPIRED_REFRESH_TOKEN);
+
+        } else if (tokenProvider.validToken(refreshToken)
+            .equals(INVALID_REFRESH_TOKEN.getErrorCode())) {
+
+            throw new TokenException(INVALID_REFRESH_TOKEN);
+        }
+
+        // 잘못된 access 토큰 값 에러
+        if (tokenProvider.validAccessToken(accessToken)
+            .equals(INVALID_ACCESS_TOKEN.getErrorCode())) {
+
+            throw new TokenException(INVALID_ACCESS_TOKEN);
+        }
+
+        // Access 토큰에서 userId 가져오기
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+
+        // userId로 User 검색
+        User user = userRepository.findById(authentication.getName())
+            .orElseThrow(() -> new UserException(NOT_FOUND_USER));
+
+        // User 에 저장된 refresh 토큰 값과 일치하지 않음
+        if (!user.getRefreshToken().equals(refreshToken)) {
+            throw new TokenException(WRONG_REFRESH_TOKEN);
+        }
+
+        // access 토큰 재발급, refresh 토큰 재발급, refresh 토큰 값 저장
+        String newAccessToken = tokenProvider.generateAccessToken(user.getEmail(), user.getRoles());
+        String newRefreshToken = tokenProvider.generateRefreshToken(user.getRoles());
+        user.setRefreshToken(newRefreshToken);
+
+        return TokenDto.builder()
+            .accessToken(newAccessToken)
+            .refreshToken(newRefreshToken)
+            .build();
+    }
+}

--- a/server/src/main/java/com/watchtogether/server/users/service/impl/UserServiceImpl.java
+++ b/server/src/main/java/com/watchtogether/server/users/service/impl/UserServiceImpl.java
@@ -127,7 +127,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserDto myPageUser(String email) {
+    public UserDto InfoUser(String email) {
 
         User user = userRepository.findById(email)
             .orElseThrow(() -> new UserException(NOT_FOUND_USER));
@@ -196,6 +196,15 @@ public class UserServiceImpl implements UserService {
         user.setResetPasswordKey("");
         user.setResetPasswordLimitDt(null);
 
+    }
+
+    @Override
+    @Transactional
+    public void saveRefreshToken(String email, String refreshToken) {
+        User user = userRepository.findById(email)
+            .orElseThrow(() -> new UserException(NOT_FOUND_USER));
+
+        user.setRefreshToken(refreshToken);
     }
 
     @Override


### PR DESCRIPTION
**개요**

- feat : 발급 된 토큰 값 만료 시 새로운 토큰 값으로 갱신 기능 추가
- chore : 토큰 값 갱신 요청 허용 설정
- fix : 로그인 시 refresh 토큰 발급 및 저장 기능 추가 및 수정

**타입**

- [x]  feat : 새로운 기능 추가
- [x]  fix : 버그 수정이나 로직 변경 등의 수정
- [ ]  build : 빌드 관련 파일 수정에 대한 커밋
- [x]  chore : 그 외 자잘한 수정에 대한 커밋(오탈자 등)
- [ ]  docs : 문서 수정에 대한 커밋
- [ ]  style : 코드 스타일 혹은 포맷 등에 관한 커밋
- [ ]  refactor : 코드 리팩토링에 대한 커밋
- [ ]  test : 테스트 코드 수정에 대한 커밋

**작업 사항**
- refreshToken 값 Entity에 추가(토큰 값 갱신 시 해당 사용자에게 발급한 토큰 값이 맞는지 검사)
- 로그인 시 토큰 값 발행 수정
  - 수정 전 : 한 개의 토큰 값만 발행
  - 수정 후 : 두 개의 토큰 값 발행(access 토큰 값과 refresh 토큰 값)
- access 토큰 값 만료 일시는 1시간, refresh 토큰 값의 만료 일시는 하루로 설정
- access 토큰 값이 만료되고 refresh 토큰 값이 만료되지 않았으면, 새로운 두개의 토큰 값 생성 및 발행
- access 토큰 값이 만료되고 refresh 토큰 값도 만료되면 로그아웃 처리(로그아웃 기능 완료시 추후 추가 예정)

**Test**🧪

- 토큰 값 갱신 API 테스트

**Others - optional**
- ![ERD](https://user-images.githubusercontent.com/36691759/199171597-bead09f4-c415-42dd-a9db-63dcd66ede7e.png)