### PR TITLE
feat: 선택 페이지 및 파티 등록 페이지 연결 및 데이터 값 전달 기능 추가

### DIFF
--- a/client/src/api/Parties.js
+++ b/client/src/api/Parties.js
@@ -13,6 +13,10 @@ const BASE_URL = `/api/v1/parties`;
  * receiversNickName: string
  * }} body
  */
+
+/**
+ * 파티 모집 글 등록하기
+ */
 export const createParty = (body, token) =>
   axios({
     url: `${BASE_URL}/create`,
@@ -24,6 +28,9 @@ export const createParty = (body, token) =>
     data: JSON.stringify(body),
   });
 
+/**
+ * 파티 신청 수락하기
+ */
 export const acceptParty = (body, token) =>
   axios({
     url: `${BASE_URL}/accept`,
@@ -35,12 +42,15 @@ export const acceptParty = (body, token) =>
     data: JSON.stringify(body),
   });
 
-export const listParty = (body) =>
+/**
+ * 파티 목록 출력하기
+ */  
+export const showPartyList = (token) =>
   axios({
     url: `${BASE_URL}/showPartyList`,
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
     },
-    data: JSON.stringify(body),
   });

--- a/client/src/components/AddParty/AddParty.jsx
+++ b/client/src/components/AddParty/AddParty.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Wrapper,
   Description,
@@ -16,7 +16,7 @@ import { toast, ToastContainer } from 'react-toastify';
 
 const AddParty = () => {
   const navigate = useNavigate();
-  const intialValues = {
+  const initialValues = {
     ottId: '',
     title: '',
     body: '',
@@ -24,16 +24,21 @@ const AddParty = () => {
     partyOttPassword: '',
     leaderNickName: '',
   };
-  const [formValues, setFormValues] = useState(intialValues);
+  const [formValues, setFormValues] = useState(initialValues);
   const [formErrors, setFormErrors] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [isVaildate, setIsValidate] = useState(false);
   const [inviteMember, setinviteMember] = useState([]);
+  
+  const {state} = useLocation();
+  const ott = state.ott['ott'];
+  initialValues.ottId = ott;
+  console.log(state, initialValues.ottId)
 
   const submitForm = () => {
     const accessToken = localStorage.getItem('access-token');
     const invite = inviteMember.length !== 0 ? inviteMember.join() : null;
-    const body = { ...formValues, receiversNickName: invite };
+    const body = { ...formValues, receiversNickName: invite, };
 
     createParty(body, accessToken)
       .then((res) => {

--- a/client/src/components/Mypage/Profile.jsx
+++ b/client/src/components/Mypage/Profile.jsx
@@ -6,8 +6,9 @@ import Avvvatars from 'avvvatars-react';
 import { getInfo } from './../../api/Users';
 
 function Profile() {
+  const accessToken = localStorage.getItem('access-token');
   const getUserInfo = () => {
-    return getInfo().then((res) => res.data);
+    return getInfo(accessToken).then((res) => res.data);
   };
   const { data } = useQuery('getInfo', getUserInfo);
   

--- a/client/src/components/PartyList/Card.jsx
+++ b/client/src/components/PartyList/Card.jsx
@@ -7,19 +7,19 @@ import {
   CardPerson,
   } from './Card.styles';
 
-export function Card({ottUrl, title, person}) {
+export function Card({ott, title, people}) {
   const navigate = useNavigate();
 
   return(
     <CardWrapper onClick={() => {
       navigate(`/signUp`)
     }}>
-      <CardOtt src={ottUrl}/>
-      <CardTitle>{title}
-        넷플릭스 패밀리 구해요!
+      <CardOtt src={ott}/>
+      <CardTitle>
+        {title}
       </CardTitle>
-      <CardPerson>{person}
-        3/4
+      <CardPerson>
+        {people}
       </CardPerson>
     </CardWrapper>
   );

--- a/client/src/components/PartyList/PartyList.jsx
+++ b/client/src/components/PartyList/PartyList.jsx
@@ -1,18 +1,19 @@
 import React, { useState } from 'react';
-import { useQuery } from 'react-query';
 import { Card } from './Card'
-import { listParty } from './../../api/Parties';
+import { showPartyList } from './../../api/Parties';
 import { Wrapper, Board } from './PartyList.styles';
+import icons from '../../mocks/platform';
 
 function PartyList() {
-  const getList = () => {
-    return listParty().then((res) => res.data);
+  const accessToken = localStorage.getItem('access-token');
+  const [boardList, setBoardList] = useState([]);
+  const getBoardList = () => {
+    return showPartyList(accessToken).then((res) => {
+      console.log(res.data)});
   };
-  const { data } = useQuery('listParty', getList);
-  const [boardList] = useState([]);
-  const sortList = () => {
-
-  };
+  getBoardList().then(result=> setBoardList(result));
+  // const sortList = () => {
+  // };
 
   return (
     <>
@@ -20,18 +21,12 @@ function PartyList() {
         <Board>
           {boardList.map((data) => (
             <Card 
-              ottUrl={`./Image/${data.ottId}`} 
+              ottUrl={data.partyOttId} 
               title={data.title} 
-              person={data.person}
+              people={data.people}
             />
           ))}
         </Board>
-        <Card/>
-        <Card/>
-        <Card/>
-        <Card/>
-        <Card/>
-        <Card/>
       </Wrapper>
     </>
   );

--- a/client/src/components/Select/Ott.jsx
+++ b/client/src/components/Select/Ott.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { Wrapper, OttButton, OttSection, ButtonSection } from './Ott.styles';
 import { Button } from '../../styles/Common';
 import { motion } from 'framer-motion';
@@ -12,6 +12,8 @@ function Ott() {
   const handleWatcha = ()=> {setOtt(3);};
   const handleDisney = ()=> {setOtt(4);};
   const handleWavve = ()=> {setOtt(5);};
+  const {state} = useLocation();
+  const role = state.role;
   
   return(
     <motion.div
@@ -22,27 +24,25 @@ function Ott() {
     >
       <Wrapper direction='column' justifyContent='flex-start'>
         <OttSection direction='column' justifyContent='flex-start'>
-          <OttButton ott={ott} clicked={(ott == 1) ? true : false} onClick={()=> handleNetflix()}>
+          <OttButton ott={ott} clicked={(ott === 1) ? true : false} onClick={()=> handleNetflix()}>
             넷플릭스
           </OttButton>
-          <OttButton ott={ott} clicked={(ott == 2) ? true : false} onClick={()=> handleTving()}>
+          <OttButton ott={ott} clicked={(ott === 2) ? true : false} onClick={()=> handleTving()}>
             티빙
           </OttButton>
-          <OttButton ott={ott} clicked={(ott == 3) ? true : false} onClick={()=> handleWatcha()}>
+          <OttButton ott={ott} clicked={(ott === 3) ? true : false} onClick={()=> handleWatcha()}>
             왓챠
           </OttButton>
-          <OttButton ott={ott} clicked={(ott == 4) ? true : false} onClick={()=> handleDisney()}>
+          <OttButton ott={ott} clicked={(ott === 4) ? true : false} onClick={()=> handleDisney()}>
             디즈니플러스
           </OttButton>
-          <OttButton ott={ott} clicked={(ott == 5) ? true : false} onClick={()=> handleWavve()}>
+          <OttButton ott={ott} clicked={(ott === 5) ? true : false} onClick={()=> handleWavve()}>
             웨이브
           </OttButton>
         </OttSection>
         <ButtonSection direction='column' justifyContent='flex-start'>
-          <Button>
-            <Link to="/addParty">
+          <Button onClick={()=> navigate('/addParty', {state: {role: {role}, ott: {ott}}})}>
               다음
-            </Link>
           </Button>
         </ButtonSection>
       </Wrapper>

--- a/client/src/components/Select/Select.jsx
+++ b/client/src/components/Select/Select.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, } from 'react-router-dom';
 import { Wrapper, SelectSection, ButtonSection, RoleTitle, RoleText, TextBox, Leader, Follower, NextButton } from './Select.styles';
 import { Button } from '../../styles/Common';
 import { motion } from 'framer-motion';
@@ -60,10 +60,8 @@ function Select() {
           </Follower>
         </SelectSection>
         <ButtonSection>
-          <Button>
-            <Link to="/ott">
+          <Button onClick={()=> navigate('/ott', {state: {role: {role}}})}>
               다음
-            </Link>
           </Button>
         </ButtonSection>
       </Wrapper>

--- a/client/src/pages/AddPartyPage.jsx
+++ b/client/src/pages/AddPartyPage.jsx
@@ -5,7 +5,7 @@ import AddParty from './../components/AddParty/AddParty';
 function AddPartyPage() {
   return (
     <>
-      <Header title="파티 모집하기" path="/ott"></Header>
+      <Header title="파티 모집하기" path="/select"></Header>
       <AddParty />
     </>
   );


### PR DESCRIPTION
**개요**
- feat: 선택 페이지 및 파티 등록 페이지 연결 및 데이터 값 전달 기능 추가

**타입**

- [x]  feat : 새로운 기능 추가
- [x]  fix : 버그 수정이나 로직 변경 등의 수정
- [ ]  build : 빌드 관련 파일 수정에 대한 커밋
- [x]  chore : 그 외 자잘한 수정에 대한 커밋(오탈자 등)
- [ ]  docs : 문서 수정에 대한 커밋
- [ ]  style : 코드 스타일 혹은 포맷 등에 관한 커밋
- [ ]  refactor : 코드 리팩토링에 대한 커밋
- [ ]  test : 테스트 코드 수정에 대한 커밋

**작업 사항**
- 파티 역할 선택 및 OTT 플랫폼 선택 페이지에서 각 페이지의 값들을 다음 페이지로 전달하는 기능을 구현했습니다.
- 파티 모집 글에 해당 값을 전달하고 모집글이 잘 등록될 수 있도록 했습니다.
- 프로필 페이지 api에 헤더 부분에 token 값을 추가하여 오류가 나지 않게 수정했습니다.
- 변수 선언과 관련하여 영어 오탈자가 있어서 수정했습니다.

**Test**🧪

**Others - optional**
![mobile](https://user-images.githubusercontent.com/104896647/199932589-8b0150c7-c438-416a-b69e-a4a0273f9b0c.gif)
