### PR TITLE
feat: 파티 모집 글 상세 페이지 구현

### DIFF
--- a/client/src/components/AddParty/AddParty.jsx
+++ b/client/src/components/AddParty/AddParty.jsx
@@ -13,11 +13,13 @@ import {
 import SearchModal from './SearchModal';
 import { createParty } from '../../api/Parties';
 import { toast, ToastContainer } from 'react-toastify';
+import { motion } from 'framer-motion';
 
 const AddParty = () => {
   const navigate = useNavigate();
+  const {state} = useLocation();
   const initialValues = {
-    ottId: '',
+    ottId: state.ott,
     title: '',
     body: '',
     partyOttId: '',
@@ -30,15 +32,12 @@ const AddParty = () => {
   const [isVaildate, setIsValidate] = useState(false);
   const [inviteMember, setinviteMember] = useState([]);
   
-  const {state} = useLocation();
-  const ott = state.ott['ott'];
-  initialValues.ottId = ott;
   console.log(state, initialValues.ottId)
 
   const submitForm = () => {
     const accessToken = localStorage.getItem('access-token');
     const invite = inviteMember.length !== 0 ? inviteMember.join() : null;
-    const body = { ...formValues, receiversNickName: invite, };
+    const body = { ...formValues, receiversNickName: invite };
 
     createParty(body, accessToken)
       .then((res) => {
@@ -116,64 +115,72 @@ const AddParty = () => {
   };
 
   return (
-    <Wrapper>
-      <ToastContainer />
-      <GatherForm onSubmit={handleSubmit}>
-        <Description>파티원을 모집하거나, 원하는 지인을 초대할 수 있어요.</Description>
-        {formErrors && <ErrorMessage className="error">{formErrors}</ErrorMessage>}
-        <Label htmlFor="title">모집 제목</Label>
-        <CustomInput
-          type="text"
-          name="title"
-          defalutValue={formValues.title}
-          onChange={handleChange}
-        />
+    <motion.div
+      className="selectPage"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <Wrapper>
+        <ToastContainer />
+        <GatherForm onSubmit={handleSubmit}>
+          <Description>파티원을 모집하거나, 원하는 지인을 초대할 수 있어요.</Description>
+          {formErrors && <ErrorMessage className="error">{formErrors}</ErrorMessage>}
+          <Label htmlFor="title">모집 제목</Label>
+          <CustomInput
+            type="text"
+            name="title"
+            defalutValue={formValues.title}
+            onChange={handleChange}
+          />
 
-        <Label htmlFor="searchMember">파티원 초대하기</Label>
-        <CustomInput
-          type="text"
-          name="searchMember"
-          placeholder="찾으려는 파티원의 닉네임을 입력해주세요."
-          value={inviteMember}
-          onClick={handleClick}
-        />
+          <Label htmlFor="searchMember">파티원 초대하기</Label>
+          <CustomInput
+            type="text"
+            name="searchMember"
+            placeholder="찾으려는 파티원의 닉네임을 입력해주세요."
+            value={inviteMember}
+            onClick={handleClick}
+          />
 
-        <Label htmlFor="ottId">OTT 플랫폼 계정</Label>
-        <CustomInput
-          mb="0"
-          type="text"
-          name="partyOttId"
-          placeholder="ID"
-          defalutValue={formValues.partyOttId}
-          onChange={handleChange}
-        />
-        <CustomInput
-          type="password"
-          name="partyOttPassword"
-          placeholder="Password"
-          defalutValue={formValues.partyOttPassword}
-          onChange={handleChange}
-        />
+          <Label htmlFor="ottId">OTT 플랫폼 계정</Label>
+          <CustomInput
+            mb="0"
+            type="text"
+            name="partyOttId"
+            placeholder="ID"
+            defalutValue={formValues.partyOttId}
+            onChange={handleChange}
+          />
+          <CustomInput
+            type="password"
+            name="partyOttPassword"
+            placeholder="Password"
+            defalutValue={formValues.partyOttPassword}
+            onChange={handleChange}
+          />
 
-        <Label htmlFor="body">모집 글</Label>
-        <Text
-          name="body"
-          placeholder="여기에 입력하세요"
-          defalutValue={formValues.body}
-          onChange={handleChange}
-        />
+          <Label htmlFor="body">모집 글</Label>
+          <Text
+            name="body"
+            placeholder="여기에 입력하세요"
+            defalutValue={formValues.body}
+            onChange={handleChange}
+          />
 
-        <SubmitButton type="submit">등록하기</SubmitButton>
-      </GatherForm>
+          <SubmitButton type="submit">등록하기</SubmitButton>
+        </GatherForm>
 
-      {isOpen && (
-        <SearchModal
-          setinviteMember={setinviteMember}
-          inviteMember={inviteMember}
-          setIsOpen={setIsOpen}
-        />
-      )}
-    </Wrapper>
+        {isOpen && (
+          <SearchModal
+            setinviteMember={setinviteMember}
+            inviteMember={inviteMember}
+            setIsOpen={setIsOpen}
+          />
+        )}
+      </Wrapper>
+    </motion.div>
+
   );
 };
 

--- a/client/src/components/PartyList/Card.jsx
+++ b/client/src/components/PartyList/Card.jsx
@@ -1,24 +1,26 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, {useState} from 'react';
 import { CardWrapper, CardOtt, CardDesc, CardTitle, CardPerson } from './Card.styles';
 import { IoIosArrowForward } from 'react-icons/io';
+import CardModal from './CardModal';
 
-export function Card({ ottUrl, title, people }) {
-  const navigate = useNavigate();
+export function Card({ cardNo, ottUrl, title, people }) {
   const image = ottUrl ? ottUrl[0].image : '';
-  console.log(ottUrl);
+  const [isClicked, setIsClicked] = useState(false);
+  const handleClick = (e) => {
+    e.preventDefault();
+    setIsClicked(true);
+  }
   return (
-    <CardWrapper
-      onClick={() => {
-        navigate(`/`);
-      }}
-    >
-      <CardOtt src={image} />
-      <CardDesc>
-        <CardTitle>{title}</CardTitle>
-        <CardPerson>모집 인원 : {people} / 4</CardPerson>
-      </CardDesc>
-      <IoIosArrowForward size={30} />
-    </CardWrapper>
+    <>
+      <CardWrapper type='button' onClick={handleClick}>
+        <CardOtt src={image} />
+        <CardDesc>
+          <CardTitle>{title}</CardTitle>
+          <CardPerson>모집 인원 : {people} / 4</CardPerson>
+        </CardDesc>
+        <IoIosArrowForward size={30} />
+      </CardWrapper>
+      {isClicked && <CardModal cardNo={cardNo} modal={setIsClicked} ottUrl={ottUrl}/>}
+    </>
   );
 }

--- a/client/src/components/PartyList/CardModal.jsx
+++ b/client/src/components/PartyList/CardModal.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { useQuery } from 'react-query';
+import { toast, ToastContainer } from 'react-toastify';
+import { ButtonContainer, SubmitButton, CancleButton } from '../../styles/Common';
+import { Title, Description } from '../Modal/Modal.styles';
+import { CardOtt, CardText, DescContainer, Desc1, Desc2 } from './CardModal.styles';
+import Modal from '../Modal/Modal';
+import { showPartyList } from '../../api/Parties';
+
+const CardModal = ({ cardNo, modal, ottUrl }) => {
+  const accessToken = localStorage.getItem('access-token');
+  const getBoardList = () => {
+    return showPartyList(accessToken).then((res) => res.data);
+  };
+  const { data } = useQuery('getBoardList', getBoardList);
+  const image = ottUrl ? ottUrl[0].image : '';
+
+  const handleClick = () => {
+    modal(false);
+  };
+
+  console.log(data[cardNo-1]);
+  
+  return (
+    <>
+      <ToastContainer />
+        {data && (
+          <Modal>
+            <Title>{data[cardNo-1].title}</Title>
+            <DescContainer direction="column" justifyContent="flex-start">
+              <Desc1 direction="row">
+                <CardOtt src={image}/>
+                <CardText>모집 인원 : {data[cardNo-1].people} / 4</CardText>
+              </Desc1>
+              <Desc2>
+                <Description>{data[cardNo-1].body}</Description>
+              </Desc2>
+            </DescContainer>
+            <ButtonContainer>
+              <CancleButton type='button' onClick={handleClick}>
+                취소하기 
+              </CancleButton>
+              <SubmitButton type='submit'>신청하기</SubmitButton>
+            </ButtonContainer>
+          </Modal>
+        )}
+    </>
+  )
+};
+
+export default CardModal;

--- a/client/src/components/PartyList/CardModal.styles.jsx
+++ b/client/src/components/PartyList/CardModal.styles.jsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+import { Flex } from '../../styles/Common';
+
+const CardOtt = styled.img`
+  height: 100%;
+  width: 12%;
+  margin-right: 1rem;
+`;
+
+const DescContainer = styled.div`
+  ${Flex}
+  width: 100%;
+  padding: 0rem;
+  margin: 0rem;
+`;
+
+const Desc1 = styled.div`
+  ${Flex}
+  width: 100%;
+`;
+
+const Desc2 = styled.div`
+  ${Flex}
+  width: 100%;
+  margin: 1rem;
+  padding: 1rem;
+  border: 0.2px solid ${(props) => props.theme.color.dark_100};
+  border-radius: 12px;
+`;
+
+const CardDesc = styled.div`
+  width: 100%;
+  padding-right: 1rem;
+`;
+
+const CardText = styled.p`
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.2rem;
+  color: ${(props) => props.theme.color.dark_500};
+`;
+
+export { CardOtt, DescContainer, CardDesc, CardText, Desc1, Desc2 };

--- a/client/src/components/PartyList/PartyList.jsx
+++ b/client/src/components/PartyList/PartyList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom'; 
 import { useQuery } from 'react-query';
 import { Card } from './Card';
 import { showPartyList } from './../../api/Parties';
@@ -8,6 +9,14 @@ import platform from '../../mocks/platform';
 function PartyList() {
   const accessToken = localStorage.getItem('access-token');
 
+  const { state } = useLocation();
+  let selectedOtt = 1;
+  if (state==null) {
+    selectedOtt = 1;
+  } else {
+    selectedOtt = state.ott;
+  };
+
   const getBoardList = () => {
     return showPartyList(accessToken).then((res) => res.data);
   };
@@ -15,17 +24,31 @@ function PartyList() {
   // 파티 리스트가 [{}, {}] 형태로 data에 쌓임
   const { data } = useQuery('getBoardList', getBoardList);
 
+  console.log(data);
+
   return (
     <>
       <Wrapper>
         {/* data가 있을 경우에만 렌더링  */}
         {data && (
           <Board>
-            {data.map((party) => (
+            {data.filter((party)=>party.ottId==selectedOtt).map((party) => (
               <Card
                 // map 사용 시 key 값 필수 -> 유니크한 값 (보통 index나 id 사용 )
                 key={party.id}
                 // platform 중에 ottId 가 같은 것만 모아서 새 배열로 리턴
+                cardNo={party.id}
+                ottUrl={party.ottId ? platform.filter((a) => a.id === party.ottId) : ''}
+                title={party.title}
+                people={party.people}
+              />
+            ))}
+            {data.filter((party)=>party.ottId!=selectedOtt).map((party) => (
+              <Card
+                // map 사용 시 key 값 필수 -> 유니크한 값 (보통 index나 id 사용 )
+                key={party.id}
+                // platform 중에 ottId 가 같은 것만 모아서 새 배열로 리턴
+                cardNo={party.id}
                 ottUrl={party.ottId ? platform.filter((a) => a.id === party.ottId) : ''}
                 title={party.title}
                 people={party.people}

--- a/client/src/components/Select/Ott.jsx
+++ b/client/src/components/Select/Ott.jsx
@@ -16,6 +16,9 @@ function Ott() {
   const { state } = useLocation();
   const role = state.role;
 
+  const leader = () => navigate('/addParty', { state: { role: role, ott: ott } });
+  const follower = () => navigate('/partyList', { state: { ott: ott } });
+
   return (
     <motion.div
       className="selectPage"
@@ -54,7 +57,7 @@ function Ott() {
           ))}
         </OttSection>
         <ButtonSection direction="column" justifyContent="flex-start">
-          <Button onClick={() => navigate('/addParty', { state: { role: role, ott: ott } })}>
+          <Button onClick={(role == true) ? leader : follower}>
             다음
           </Button>
         </ButtonSection>


### PR DESCRIPTION
**개요**
feat: 파티 모집 글 상세 페이지 틀 구현

**타입**

- [x]  feat : 새로운 기능 추가
- [x]  fix : 버그 수정이나 로직 변경 등의 수정
- [ ]  build : 빌드 관련 파일 수정에 대한 커밋
- [ ]  chore : 그 외 자잘한 수정에 대한 커밋(오탈자 등)
- [ ]  docs : 문서 수정에 대한 커밋
- [ ]  style : 코드 스타일 혹은 포맷 등에 관한 커밋
- [ ]  refactor : 코드 리팩토링에 대한 커밋
- [ ]  test : 테스트 코드 수정에 대한 커밋

**작업 사항**
- 파티 모집 글 상세 페이지 틀을 만들고 해당 정보를 서버로부터 불러올 수 있도록 구현했습니다.
- 파티 모집 글 목록에서 파티원이 선택한 ott 플랫폼을 상단에 노출할 수 있도록 필터를 적용했습니다.
- 파티 모집 선택 시 파티원과 파티장 역할에 따라 파티 등록 페이지와 파티 모집 리스트 페이지를 따로 노출할 수 있게 구현했습니다.
- 파티 등록 페이지에 모션을 추가했습니다.

**Test**🧪

**Others - optional**