### PR TITLE
feat: 내 파티 목록, 파티 상세 및 파티 나가기 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "formik": "^2.2.9",
         "framer-motion": "^7.6.4",
         "http-proxy-middleware": "^2.0.6",
+        "moment": "^2.29.4",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-cookie": "^4.1.1",
@@ -11796,6 +11797,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -25826,6 +25835,11 @@
       "requires": {
         "minimist": "^1.2.6"
       }
+    },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "formik": "^2.2.9",
     "framer-motion": "^7.6.4",
     "http-proxy-middleware": "^2.0.6",
+    "moment": "^2.29.4",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-cookie": "^4.1.1",

--- a/client/src/api/Parties.js
+++ b/client/src/api/Parties.js
@@ -92,8 +92,8 @@ export const joinParty = (body, token) =>
  */
  export const leave = (body, token) => {
   return axios({
-    url: `${BASE_URL}/`,
-    method: 'DELETE',
+    url: `${BASE_URL}/leave`,
+    method: 'POST',
     headers: {
       'Content-Type': 'application/json;charset=UTF-8',
       Authorization: `Bearer ${token}`,

--- a/client/src/api/Parties.js
+++ b/client/src/api/Parties.js
@@ -85,3 +85,19 @@ export const joinParty = (body, token) =>
     data: JSON.stringify(body),
   });
 };
+
+/**
+ * 파티 나가기
+ * @param {{nickName : string, partyId: 0}} body
+ */
+ export const leave = (body, token) => {
+  return axios({
+    url: `${BASE_URL}/`,
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+      Authorization: `Bearer ${token}`,
+    },
+    data: JSON.stringify(body),
+  });
+};

--- a/client/src/components/MyParty/AlertModal.jsx
+++ b/client/src/components/MyParty/AlertModal.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast, ToastContainer } from 'react-toastify';
+
+import { ButtonContainer, SubmitButton, CancleButton } from '../../styles/Common';
+import { AlertTitle, AlertText } from '../Modal/Modal.styles';
+
+import Modal from '../Modal/Modal';
+import { leave } from '../../api/Parties';
+
+const AlertModal = ({ modal, data, leaderNickname }) => {
+  const navigate = useNavigate();
+  const handleClick = (e) => {
+    const name = e.target.dataset.name;
+    if (name === 'cancle') modal(false);
+    if (name === 'leave') {
+      if (data.nickName === leaderNickname) {
+        toast.error(<h1>파티장은 파티를 나갈 수 없습니다! 😠</h1>, {position: 'top-center', autoClose: 2000,});
+        setTimeout(() => {
+          modal(false);
+        }, 2000);
+      }
+      else {
+        leaveParty();
+      }
+    }
+  };
+
+  const leaveParty = () => {
+    const accessToken = localStorage.getItem('access-token');
+
+    leave(data, accessToken)
+      .then((res) => {
+        console.log(res.data);
+        toast.success(
+          <>
+            <h1>파티 나가기 완료</h1>
+          </>,
+          {
+            position: 'top-center',
+            autoClose: 1500,
+          },
+        );
+
+        setTimeout(() => {
+          modal(false);
+          navigate('/mypage');
+        }, 1500);
+      })
+      .catch((error) => {
+        console.log(error);
+        console.log(error.response.data.message);
+      });
+  };
+
+  return (
+    <>
+      <ToastContainer />
+      <Modal>
+        <AlertTitle>파티 나가기</AlertTitle>
+        <AlertText>정말 파티를 나가시겠습니까? 😥</AlertText>
+        <ButtonContainer>
+          <CancleButton type="button" onClick={handleClick} data-name="cancle">
+            취소하기
+          </CancleButton>
+          <SubmitButton type="button" onClick={handleClick} data-name="leave">
+            파티 나가기
+          </SubmitButton>
+        </ButtonContainer>
+      </Modal>
+    </>
+  );
+};
+
+export default AlertModal;

--- a/client/src/components/MyParty/Card.jsx
+++ b/client/src/components/MyParty/Card.jsx
@@ -1,73 +1,24 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { CardWrapper, CardDesc, InfoList, } from './Card.styles';
+import { CardWrapper, CardDesc, InfoList } from './Card.styles';
 import { IoIosArrowForward } from 'react-icons/io';
-export function Card({ data }) {
-  const {myParty} = data;
-  const { title, partyId, body, amount, startDt, endDt, ott, member } = myParty;
-  const navigate = useNavigate();
+import otts from '../../mocks/platform';
 
+export function Card({ data }) {
+  console.log(data);
+
+  const { id, title, ottId } = data;
+  const navigate = useNavigate();
+  const ottUrl = otts.filter((a) => a.id === ottId); // 로고 가져오려고 썼어요
+
+  // 사용자가 버튼을 클릭하면 id가 28이라고 가정할 때, mypage/myparty/28 로 이동하게 되고, id 28에 대한 데이터가 state로 담겨요!
   return (
     <>
-      <CardWrapper type='button' onClick = { () => navigate('./{$partyId}', { state: {data: myParty} })}>
+      <CardWrapper type="button" onClick={() => navigate(`./${id}`, { state: { data: data } })}>
         <CardDesc>
           <InfoList>
-            <li>
-              <span>
-                파티명: 
-              </span>
-              <span>
-                {title}
-              </span>
-            </li>
-            <li>
-              <span>
-                파티 소개: 
-              </span>
-              <span>
-                {body}
-              </span>
-            </li>
-            <li>
-              <span>
-                amount: 
-              </span>
-              <span>
-                {amount}
-              </span>
-            </li>
-            <li>
-              <span>
-                파티 생성일: 
-              </span>
-              <span>
-                {startDt}
-              </span>
-            </li>
-            <li>
-              <span>
-                파티 종료일: 
-              </span>
-              <span>
-                {endDt}
-              </span>
-            </li>
-            <li>
-              <span>
-                OTT 플랫폼: 
-              </span>
-              <span>
-                {ott}
-              </span>
-            </li>
-            <li>
-              <span>
-                구성 멤버: 
-              </span>
-              <span>
-                {member}
-              </span>
-            </li>
+            <img src={ottUrl[0].image} alt="" width="50px" height="50px" />
+            <h2>{title}</h2>
           </InfoList>
         </CardDesc>
         <IoIosArrowForward size={30} />

--- a/client/src/components/MyParty/Card.jsx
+++ b/client/src/components/MyParty/Card.jsx
@@ -4,8 +4,8 @@ import { CardWrapper, CardDesc, InfoList } from './Card.styles';
 import { IoIosArrowForward } from 'react-icons/io';
 import otts from '../../mocks/platform';
 
-export function Card({ data }) {
-  console.log(data);
+export function Card({ data, nickName }) {
+  console.log(data, nickName);
 
   const { id, title, ottId } = data;
   const navigate = useNavigate();
@@ -14,7 +14,7 @@ export function Card({ data }) {
   // 사용자가 버튼을 클릭하면 id가 28이라고 가정할 때, mypage/myparty/28 로 이동하게 되고, id 28에 대한 데이터가 state로 담겨요!
   return (
     <>
-      <CardWrapper type="button" onClick={() => navigate(`./${id}`, { state: { data: data } })}>
+      <CardWrapper type="button" onClick={() => navigate(`./${id}`, { state: { data: data, nickName: nickName } })}>
         <CardDesc>
           <InfoList>
             <img src={ottUrl[0].image} alt="" width="50px" height="50px" />

--- a/client/src/components/MyParty/MyParty.jsx
+++ b/client/src/components/MyParty/MyParty.jsx
@@ -37,7 +37,7 @@ function MyParty() {
           <Board>
             <h2>대기 중 파티</h2>
             {waiting.map((party) => (
-              <Card key={party.id} data={party} />
+              <Card key={party.id} data={party} nickName={nickName} />
             ))}
           </Board>
         )}
@@ -45,7 +45,7 @@ function MyParty() {
           <Board>
             <h2>내 파티</h2>
             {myParty.map((party) => (
-              <Card key={party.id} data={party} />
+              <Card key={party.id} data={party} nickName={nickName} />
             ))}
           </Board>
         )}

--- a/client/src/components/MyParty/MyParty.jsx
+++ b/client/src/components/MyParty/MyParty.jsx
@@ -1,42 +1,51 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import { findMyParties } from './../../api/Parties';
 import { getInfo } from './../../api/Users';
-import { Wrapper, Board} from './MyParty.styles';
+import { Wrapper, Board } from './MyParty.styles';
 import { Card } from './Card';
 
 function MyParty() {
+  let nickName = '';
   const accessToken = localStorage.getItem('access-token');
-  const myParties = () => {
-    return findMyParties(body, accessToken).then((res) => res.data);
-  };
+  const [myParty, setMyParty] = useState();
+  const [waiting, setWaiting] = useState();
   const getUserInfo = () => {
     return getInfo(accessToken).then((res) => res.data);
   };
 
   const { data } = useQuery('getInfo', getUserInfo);
-  const { data2 } = useQuery('findMyParties', myParties);
 
-  let nickName = '';
   if (data) {
     nickName = data.nickname;
-  };
-  const navigate = useNavigate();
-  const body = {nickName: nickName};
-  console.log(data)
-  console.log(data2)
+  }
+
+  const body = { nickName: nickName };
+
+  useEffect(() => {
+    findMyParties(body, accessToken).then((res) => {
+      setMyParty(res.data[0]); // 완성된 파티
+      setWaiting(res.data[1]); // 대기중인 파티
+    });
+  }, [data]);
 
   return (
     <>
       <Wrapper>
-        {data2 && (
+        {waiting && (
           <Board>
-            {data2.list.map((myParty) => (
-            <Card
-              key = {myParty.partyId}
-              data = {myParty}
-            />
+            <h2>대기 중 파티</h2>
+            {waiting.map((party) => (
+              <Card key={party.id} data={party} />
+            ))}
+          </Board>
+        )}
+        {myParty && (
+          <Board>
+            <h2>내 파티</h2>
+            {myParty.map((party) => (
+              <Card key={party.id} data={party} />
             ))}
           </Board>
         )}

--- a/client/src/components/MyParty/MyPartyDetail.jsx
+++ b/client/src/components/MyParty/MyPartyDetail.jsx
@@ -1,17 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import AlertModal from './AlertModal';
 import { Wrapper, Board, Withdrawal, InfoList } from './MyPartyDetail.styles';
 import 'moment/locale/ko';
 import otts from '../../mocks/platform';
 
 function MyPartyDetail() {
+  const [isLeave, setIsLeave] = useState(false);
   const { state } = useLocation();
   const moment = require("moment");
-  const { title, body, members, ottId, createdDt, people } = state.data;
+  const { id, title, body, members, ottId, createdDt, people, leaderNickname } = state.data;
+  const nickName = state.nickName;
   const createdDate = moment(createdDt.toString()).format('YYYY년 MM월 DD일, HH시 mm분');
   const ottUrl = otts.filter((a) => a.id === ottId);
   const ottName = ottUrl[0].name;
   const { partyOttId, partyOttPassword } = state.data;
+
+  const leaveData = {nickName: nickName, partyId: id};
+
+  const handleClick = (e) => {
+    e.preventDefault();
+    const name = e.target.dataset.name;
+    // if (name === 'changePassword') setIsChange(true);
+    if (name === 'leave') setIsLeave(true);
+  };
   
   console.log(state);
 
@@ -54,9 +66,11 @@ function MyPartyDetail() {
           </li>
           </InfoList>
         </Board>
-        <Withdrawal>파티 나가기</Withdrawal>
+        <Withdrawal type="button" onClick={handleClick} data-name="leave">파티 나가기</Withdrawal>
         <Withdrawal>OTT 비밀번호 변경하기</Withdrawal>
       </Wrapper>
+
+      {isLeave && <AlertModal modal={setIsLeave} data={leaveData} leaderNickname={leaderNickname} />}
     </>
   );
 }

--- a/client/src/components/MyParty/MyPartyDetail.jsx
+++ b/client/src/components/MyParty/MyPartyDetail.jsx
@@ -1,24 +1,40 @@
 import React from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
-import { Wrapper, Board} from './MyPartyDetail.styles';
+import { Wrapper, Board } from './MyPartyDetail.styles';
 
 function MyPartyDetail() {
-  const navigate = useNavigate();
-  const params = useParams();
-  const { data } = useLocation();
-
-  console.log(params.id)
-  console.log(data)
-
+  const { state } = useLocation();
+  const { title, body, members, ottId, createdDt, invisibleDt } = state.data;
   return (
     <>
-      {data.partyId == parms.id && (
       <Wrapper>
         <Board>
-          하이
+          <li>
+            <span>파티명:</span>
+            <span>{title}</span>
+          </li>
+          <li>
+            <span>파티 소개:</span>
+            <span>{body}</span>
+          </li>
+          <li>
+            <span>파티 생성일:</span>
+            <span>{createdDt}</span>
+          </li>
+          <li>
+            <span>파티 종료일:</span>
+            <span>{invisibleDt}</span>
+          </li>
+          <li>
+            <span>OTT 플랫폼:</span>
+            <span>{ottId}</span>
+          </li>
+          <li>
+            <span>구성 멤버:</span>
+            <span>{members.map((a) => a.nickName).join(', ')}</span>
+          </li>
         </Board>
       </Wrapper>
-      )}
     </>
   );
 }

--- a/client/src/components/MyParty/MyPartyDetail.jsx
+++ b/client/src/components/MyParty/MyPartyDetail.jsx
@@ -1,39 +1,61 @@
 import React from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
-import { Wrapper, Board } from './MyPartyDetail.styles';
+import { Wrapper, Board, Withdrawal, InfoList } from './MyPartyDetail.styles';
+import 'moment/locale/ko';
+import otts from '../../mocks/platform';
 
 function MyPartyDetail() {
   const { state } = useLocation();
-  const { title, body, members, ottId, createdDt, invisibleDt } = state.data;
+  const moment = require("moment");
+  const { title, body, members, ottId, createdDt, people } = state.data;
+  const createdDate = moment(createdDt.toString()).format('YYYY년 MM월 DD일, HH시 mm분');
+  const ottUrl = otts.filter((a) => a.id === ottId);
+  const ottName = ottUrl[0].name;
+  const { partyOttId, partyOttPassword } = state.data;
+  
+  console.log(state);
+
   return (
     <>
       <Wrapper>
         <Board>
+          <InfoList>
           <li>
-            <span>파티명:</span>
+            <span>파티명: </span>
             <span>{title}</span>
           </li>
           <li>
-            <span>파티 소개:</span>
+            <span>파티 소개: </span>
             <span>{body}</span>
           </li>
           <li>
-            <span>파티 생성일:</span>
-            <span>{createdDt}</span>
+            <span>파티 생성일: </span>
+            <span>{createdDate}</span>
           </li>
           <li>
-            <span>파티 종료일:</span>
-            <span>{invisibleDt}</span>
+            <span>파티 인원: </span>
+            <span>{people} 명</span>
           </li>
           <li>
-            <span>OTT 플랫폼:</span>
-            <span>{ottId}</span>
+            <span>OTT 플랫폼: </span>
+            <span>{ottName}</span>
           </li>
           <li>
-            <span>구성 멤버:</span>
+            <span>계정 아이디: </span>
+            <span>{people == 4? partyOttId: '파티 대기 중'}</span>
+          </li>
+          <li>
+            <span>계정 비밀번호: </span>
+            <span>{people == 4? partyOttPassword: '파티 대기 중'}</span>
+          </li>
+          <li>
+            <span>구성 멤버: </span>
             <span>{members.map((a) => a.nickName).join(', ')}</span>
           </li>
+          </InfoList>
         </Board>
+        <Withdrawal>파티 나가기</Withdrawal>
+        <Withdrawal>OTT 비밀번호 변경하기</Withdrawal>
       </Wrapper>
     </>
   );

--- a/client/src/components/MyParty/MyPartyDetail.styles.jsx
+++ b/client/src/components/MyParty/MyPartyDetail.styles.jsx
@@ -9,4 +9,28 @@ const Board = styled.div`
   width: 100%;
 `;
 
-export { Wrapper, Board };
+const Withdrawal = styled.button`
+  font-size: 0.9rem;
+  color: ${(props) => props.theme.color.error_300};
+  background-color: transparent;
+`;
+
+const InfoList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+
+  li {
+    width: 100%;
+    padding: 0.5rem 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.8rem;
+    font-weight: 400;
+    line-height: 1.2rem;
+  }
+`;
+
+export { Wrapper, Board, Withdrawal, InfoList };

--- a/client/src/components/Payment/Card.jsx
+++ b/client/src/components/Payment/Card.jsx
@@ -1,33 +1,26 @@
 import React from 'react';
-import { CardWrapper, CardDesc, InfoList, Visible } from './Card.styles';
+import { useNavigate } from 'react-router-dom';
+import { CardWrapper, CardDesc, InfoList } from './Card.styles';
+import { IoIosArrowForward } from 'react-icons/io';
+import otts from '../../mocks/platform';
 
-export function Card({ trader, dt, result, type }) {
-  const traderIsNull = trader;
-  console.log(traderIsNull);
+export function Card({ data }) {
+  console.log(data);
+  const { id, title, ottId } = data;
+  const navigate = useNavigate();
+  const ottUrl = otts.filter((a) => a.id === ottId);
 
+  // 사용자가 버튼을 클릭하면 id가 28이라고 가정할 때, mypage/myparty/28 로 이동하게 되고, id 28에 대한 데이터가 state로 담겨요!
   return (
     <>
-      <CardWrapper type='button'>
+      <CardWrapper type="button" onClick={() => navigate(`./${id}`, { state: { data: data } })}>
         <CardDesc>
           <InfoList>
-            <li>
-              <span>결제일: </span>
-              <span>{dt}</span>
-            </li>
-            <li>
-              <span>결제 결과: </span>
-              <span>{result}</span>
-            </li>
-            <li>
-              <span>결제 유형: </span>
-              <span>{type}</span>
-            </li>
-            <li>
-              <Visible>거래자 닉네임: </Visible>
-              <Visible trader = {trader}>{trader}</Visible>
-            </li>
+            <img src={ottUrl[0].image} alt="" width="50px" height="50px" />
+            <h2>{title}</h2>
           </InfoList>
         </CardDesc>
+        <IoIosArrowForward size={30} />
       </CardWrapper>
     </>
   );

--- a/client/src/components/Payment/Card.jsx
+++ b/client/src/components/Payment/Card.jsx
@@ -1,26 +1,36 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import { CardWrapper, CardDesc, InfoList } from './Card.styles';
-import { IoIosArrowForward } from 'react-icons/io';
-import otts from '../../mocks/platform';
+import { CardWrapper, CardDesc, InfoList, Visible } from './Card.styles';
+import 'moment/locale/ko';
 
-export function Card({ data }) {
-  console.log(data);
-  const { id, title, ottId } = data;
-  const navigate = useNavigate();
-  const ottUrl = otts.filter((a) => a.id === ottId);
+export function Card({ trader, dt, result, type }) {
+  const traderIsNull = trader;
+  const moment = require("moment");
+  const date = moment(dt.toString()).format('YY년 MM월 DD일, HH시 mm분 ss초');
+  console.log(traderIsNull);
 
-  // 사용자가 버튼을 클릭하면 id가 28이라고 가정할 때, mypage/myparty/28 로 이동하게 되고, id 28에 대한 데이터가 state로 담겨요!
   return (
     <>
-      <CardWrapper type="button" onClick={() => navigate(`./${id}`, { state: { data: data } })}>
+      <CardWrapper type='button'>
         <CardDesc>
           <InfoList>
-            <img src={ottUrl[0].image} alt="" width="50px" height="50px" />
-            <h2>{title}</h2>
+            <li>
+              <span>결제일: </span>
+              <span>{date}</span>
+            </li>
+            <li>
+              <span>결제 결과: </span>
+              <span>{result}</span>
+            </li>
+            <li>
+              <span>결제 유형: </span>
+              <span>{type}</span>
+            </li>
+            <li>
+              <Visible>거래자 닉네임: </Visible>
+              <Visible trader = {trader}>{trader}</Visible>
+            </li>
           </InfoList>
         </CardDesc>
-        <IoIosArrowForward size={30} />
       </CardWrapper>
     </>
   );

--- a/client/src/components/Payment/Card.styles.jsx
+++ b/client/src/components/Payment/Card.styles.jsx
@@ -34,8 +34,24 @@ const InfoList = styled.ul`
   }
 `;
 
+
+const Highlight = styled.p`
+  color: ${(props) => props.theme.color.highlight_500};
+  font-weight: 600;
+`;
+
+const HighlightTwo = styled.p`
+  color: ${(props) => props.theme.color.success_300};
+  font-weight: 600;
+`;
+
+const HighlightRed = styled.p`
+  color: ${(props) => props.theme.color.warning_300};
+  font-weight: 600;
+`;
+
 const Visible = styled.span`
   display: ${ props => (props.trader == null) ? 'none': '' };
 `;
 
-export { CardWrapper, CardDesc, InfoList, Visible };
+export { CardWrapper, CardDesc, InfoList, Visible, Highlight, HighlightTwo, HighlightRed };

--- a/client/src/pages/MyPartyDetailPage.jsx
+++ b/client/src/pages/MyPartyDetailPage.jsx
@@ -5,7 +5,7 @@ import MyPartyDetail from '../components/MyParty/MyPartyDetail';
 const MyPartyDetailPage = () => {
   return (
     <>
-      <Header title="내 파티 상세보기" path="mypage/myparty"></Header>
+      <Header title="내 파티 상세보기" path="/mypage"></Header>
       <MyPartyDetail />
     </>
   );


### PR DESCRIPTION
**개요**
- feat: 내 파티 목록, 파티 상세 및 파티 나가기 구현

**타입**

- [x]  feat : 새로운 기능 추가
- [x]  fix : 버그 수정이나 로직 변경 등의 수정
- [ ]  build : 빌드 관련 파일 수정에 대한 커밋
- [x]  chore : 그 외 자잘한 수정에 대한 커밋(오탈자 등)
- [ ]  docs : 문서 수정에 대한 커밋
- [ ]  style : 코드 스타일 혹은 포맷 등에 관한 커밋
- [ ]  refactor : 코드 리팩토링에 대한 커밋
- [ ]  test : 테스트 코드 수정에 대한 커밋

**작업 사항**
- 내 파티 목록과 상세 페이지를 구현했습니다.
- 내 파티 목록의 데이터를 서버에서 불러오는 것과 컴포넌트 별로 이를 주고 받는 코드와 관련하여 FE_박지호님께서 많은 도움 주셨습니다.
- 내 파티 상세 목록에서 파티가 대기 중인 경우, OTT 계정 아이디와 비밀번호가 보이지 않도록 구현했습니다.
- 내 파티 상세 목록 및 결제 내역 페이지의 날짜 서식을 수정했습니다.
- 내 파티 나가기 기능을 구현했습니다.
- 내 파티 나가기를 파티장은 나가지 못하도록 구현했습니다. 

**Test**🧪

**Others - optional**
![mobile](https://user-images.githubusercontent.com/104896647/201295621-32293fa5-cdeb-4138-b981-4df324967e6a.gif)
![오류](https://user-images.githubusercontent.com/104896647/201294335-88158d21-cc0c-44fe-8a66-2722ad6cb10a.png)
파티장 역시 나갈 경우에 인원은 없어졌으나, 파티는 그대로 남아 있는 오류가 있습니다.
이를 프론트 측면에서 우선 파티장은 파티를 나가지 못하도록 막는 방식으로 해결했습니다.
파티 방을 아예 없애버리는 것과 관련하여 추후 논의하면 좋을 것 같습니다.
