### PR TITLE
fix : 파티 참가 전, 사용자 거래 내역 확인

### DIFF
--- a/server/src/main/java/com/watchtogether/server/exception/type/TransactionErrorCode.java
+++ b/server/src/main/java/com/watchtogether/server/exception/type/TransactionErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum TransactionErrorCode {
 
     INSUFFICIENT_CASH(HttpStatus.UNAUTHORIZED.value(), "INSUFFICIENT_CASH", "캐쉬가 부족합니다."),
-    INVALID_REQUEST(HttpStatus.UNAUTHORIZED.value(), "INVALID_REQUEST", "잘못된 요청입니다.");
+    INVALID_REQUEST(HttpStatus.UNAUTHORIZED.value(), "INVALID_REQUEST", "잘못된 요청입니다."),
+    NOT_FOUND_PREPAYMENT_HISTORY(HttpStatus.UNAUTHORIZED.value(), "NOT_FOUND_PREPAYMENT_HISTORY", "선결제 대기 내역을 찾을 수 없습니다.");
 
     private final int errorStatus;
     private final String errorCode;

--- a/server/src/main/java/com/watchtogether/server/ott/domain/dto/OttDto.java
+++ b/server/src/main/java/com/watchtogether/server/ott/domain/dto/OttDto.java
@@ -19,14 +19,13 @@ public class OttDto {
     private Long fee;
     private String imagePath;
 
-    public static OttDto fromEntity(Ott ott){
+    public static OttDto fromEntity(Ott ott) {
         return OttDto.builder()
             .id(ott.getId())
             .name(ott.getName())
             .commissionLeader(ott.getCommissionLeader())
             .commissionMember(ott.getCommissionMember())
             .fee(ott.getFee())
-            .imagePath(ott.getImagePath())
             .build();
     }
 }

--- a/server/src/main/java/com/watchtogether/server/ott/domain/entity/Ott.java
+++ b/server/src/main/java/com/watchtogether/server/ott/domain/entity/Ott.java
@@ -16,8 +16,9 @@ import org.hibernate.envers.AuditOverride;
 @AuditOverride(forClass = BaseEntity.class)
 @AllArgsConstructor
 @NoArgsConstructor
-@Entity(name="ott")
-public class Ott extends BaseEntity{
+@Entity(name = "ott")
+public class Ott extends BaseEntity {
+
     @Id
     @Column(name = "ott_id")
     private Long id;
@@ -35,6 +36,5 @@ public class Ott extends BaseEntity{
     // 500원으로 통일
     private Long fee;
     // 전체금액 / 4
-    private  String imagePath;
-    // 이미지 경로
+
 }

--- a/server/src/main/java/com/watchtogether/server/users/controller/TransactionController.java
+++ b/server/src/main/java/com/watchtogether/server/users/controller/TransactionController.java
@@ -101,7 +101,7 @@ public class TransactionController {
 
         TransactionDto transactionDto =
             transactionApplicaion.userCashWithdrawCancel(
-                 request.getPartyId(),
+                request.getPartyId(),
                 user.getNickname());
 
         return ResponseEntity.ok(
@@ -117,14 +117,4 @@ public class TransactionController {
             )
         );
     }
-
-//    @GetMapping("/test")
-//    @Operation(summary = "test", description = "test.")
-//    public ResponseEntity<?> test() {
-//
-//        TransactionDto transactionDto =
-//            transactionApplicaion.test();
-//
-//        return ResponseEntity.ok(null);
-//    }
 }

--- a/server/src/main/java/com/watchtogether/server/users/service/Application/TransactionApplicaion.java
+++ b/server/src/main/java/com/watchtogether/server/users/service/Application/TransactionApplicaion.java
@@ -50,23 +50,4 @@ public class TransactionApplicaion {
             ottDto.getFee());
 
     }
-
-//    public TransactionDto test() {
-//
-//        List<Party> partyList = partyRepository.findByPayDt(LocalDate.now());
-//        for (Party party : partyList) {
-//            // 결제 진행부분 삽입
-//
-//            OttDto ottDto = ottService.searchOtt(party.getOttId());
-//
-//            transactionService.userCashDeposit(
-//                party.getMembers(),
-//                party.getLeaderNickname(),
-//                party.getId(),
-//                ottDto.getCommissionLeader(),
-//                ottDto.getFee());
-//        }
-//
-//        return null;
-//    }
 }

--- a/server/src/main/java/com/watchtogether/server/users/service/TransactionService.java
+++ b/server/src/main/java/com/watchtogether/server/users/service/TransactionService.java
@@ -2,6 +2,7 @@ package com.watchtogether.server.users.service;
 
 import com.watchtogether.server.party.domain.entitiy.PartyMember;
 import com.watchtogether.server.users.domain.dto.TransactionDto;
+import com.watchtogether.server.users.domain.entitiy.Transaction;
 import java.util.List;
 
 public interface TransactionService {
@@ -81,4 +82,14 @@ public interface TransactionService {
      * @param email 사용자 이메일
      */
     void deleteTransaction(String email);
+
+    /**
+     * 사용자 거래내역 확인
+     *
+     * @param partId   파티아이디
+     * @param nickname 사용자 닉네임
+     * @return
+     */
+    List<Transaction> checkTransaction(Long partId, String nickname);
+
 }


### PR DESCRIPTION
**개요**

- fix : 파티 참가 전, 사용자 거래 내역 확인
- fix : ott imagePath 컬럼 삭제

**타입**

- [ ]  feat : 새로운 기능 추가
- [x]  fix : 버그 수정이나 로직 변경 등의 수정
- [ ]  build : 빌드 관련 파일 수정에 대한 커밋
- [ ]  chore : 그 외 자잘한 수정에 대한 커밋(오탈자 등)
- [ ]  docs : 문서 수정에 대한 커밋
- [ ]  style : 코드 스타일 혹은 포맷 등에 관한 커밋
- [ ]  refactor : 코드 리팩토링에 대한 커밋
- [ ]  test : 테스트 코드 수정에 대한 커밋

**작업 사항**
- 사용자 파티 참가 전, 사용자가 선결제 했는지 거래내역 확인 추가
  - 아래 화면 195번 라인에 **checkTransaction(Long partId, String nickname)** 서비스 메소드 추가 필요
https://github.com/FeBeProject/watchTogether/blob/4ec8e4f4c77ad8d3325caab4d70396b7dab391eb/server/src/main/java/com/watchtogether/server/party/service/Application/CheckPartyApplication.java#L194-L204

- ott imagePath 컬럼 삭제

**Test**🧪

- 사용자 파티 참가 전, 사용자가 선결제 했는지 거래내역 확인 테스트

**Others - optional**
- 스크린샷이나 참고한 링크